### PR TITLE
Fix endPoint ending up in qs

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,17 +58,19 @@ class TinySpeck extends EventEmitter {
    * @return {Promise} A promise with the API result
    */
   send(...args) {
-    // use defaults when available
-    let message = Object.assign({}, this.defaults, ...args)
-
     // default action is post message
     let endPoint = 'chat.postMessage'
 
     // if an endpoint was passed in, use it
     if (typeof args[0] === 'string') endPoint = args.shift()
 
+    // use defaults when available
+    const message = Object.assign({}, this.defaults, ...args)
+
     // call update if ts included and no endpoint
-    else if (message.ts) endPoint = 'chat.update'
+    if (endPoint === 'chat.PostMessage' && message.ts) {
+      endPoint = 'chat.update'
+    }
 
     // convert content-type if webapi endpoint
     if (!endPoint.match(/^http/i)) {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class TinySpeck extends EventEmitter {
     if (typeof args[0] === 'string') endPoint = args.shift()
 
     // use defaults when available
-    const message = Object.assign({}, this.defaults, ...args)
+    let message = Object.assign({}, this.defaults, ...args)
 
     // call update if ts included and no endpoint
     if (endPoint === 'chat.PostMessage' && message.ts) {


### PR DESCRIPTION
Without, calling `send('users.list', { presence: 'true' })` will get you:

```
0=u&1=s&2=e&3=r&4=s&5=.&6=l&7=i&8=s&9=t&token=my-token&presence=true
```

With:

```
token=token&presence=true
```